### PR TITLE
fixes rustdoc lint warning

### DIFF
--- a/heim-common/src/lib.rs
+++ b/heim-common/src/lib.rs
@@ -14,7 +14,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,

--- a/heim-cpu/src/lib.rs
+++ b/heim-cpu/src/lib.rs
@@ -18,7 +18,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,

--- a/heim-derive/src/lib.rs
+++ b/heim-derive/src/lib.rs
@@ -15,7 +15,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,

--- a/heim-disk/src/lib.rs
+++ b/heim-disk/src/lib.rs
@@ -12,7 +12,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,

--- a/heim-host/src/lib.rs
+++ b/heim-host/src/lib.rs
@@ -12,7 +12,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,

--- a/heim-memory/src/lib.rs
+++ b/heim-memory/src/lib.rs
@@ -12,7 +12,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,

--- a/heim-net/src/lib.rs
+++ b/heim-net/src/lib.rs
@@ -12,7 +12,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,

--- a/heim-process/src/lib.rs
+++ b/heim-process/src/lib.rs
@@ -12,7 +12,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,

--- a/heim-runtime/src/lib.rs
+++ b/heim-runtime/src/lib.rs
@@ -11,7 +11,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links,
+    rustdoc::broken_intra_doc_links,
 )]
 #![warn(
     trivial_casts,

--- a/heim-sensors/src/lib.rs
+++ b/heim-sensors/src/lib.rs
@@ -12,7 +12,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,

--- a/heim-virt/src/lib.rs
+++ b/heim-virt/src/lib.rs
@@ -18,7 +18,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,

--- a/heim/src/lib.rs
+++ b/heim/src/lib.rs
@@ -56,7 +56,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(
     trivial_casts,


### PR DESCRIPTION
Fixes the following warning:

```
warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
```